### PR TITLE
feature gates are required to compile with recent nightlies

### DIFF
--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -13,7 +13,7 @@ cortex-m-rtfm = "0.2.0"
 
 [dependencies.blue-pill]
 git = "https://github.com/japaric/blue-pill"
-rev = "2b7d5c56b25f4efad6c7c40042f884cbecb47c0b"
+rev = "849aa44a290400cc1b6659a7773ba31b097a696d"
 
 [dependencies.cortex-m-rt]
 features = ["abort-on-panic"]

--- a/sequence/src/main.rs
+++ b/sequence/src/main.rs
@@ -12,6 +12,7 @@ use rand::{Rng, XorShiftRng};
 
 use errors::*;
 
+#[allow(unused_doc_comment)]
 mod errors {
     error_chain! {
         foreign_links {


### PR DESCRIPTION
The japaric/blue-pill commit 3efe73cfef74a334892a9b34f0f04659522aadfa
'add "const fn" related features gates' is required to compile with
recent versions of nightly. This commit changes the blue-pill dependency
to include this commit.